### PR TITLE
BVAL-293 BVAL-292

### DIFF
--- a/src/main/java/javax/validation/BootstrapConfiguration.java
+++ b/src/main/java/javax/validation/BootstrapConfiguration.java
@@ -25,7 +25,7 @@ import java.util.Set;
  * @author Gunnar Morling
  * @author Hardy Ferentschik
  */
-public interface XMLConfiguration {
+public interface BootstrapConfiguration {
 	/**
 	 * Class name of the {@code ValidationProvider} implementation
 	 * or {@code null} if none is specified.

--- a/src/main/java/javax/validation/Configuration.java
+++ b/src/main/java/javax/validation/Configuration.java
@@ -228,11 +228,11 @@ public interface Configuration<T extends Configuration<T>> {
 	 * <b>Note</b>:<br/>
 	 * Implementations are encouraged to lazily build this object to delay parsing.
 	 *
-	 * @return Returns an instance of {@code XMLConfiguration}. This method returns never {@code null}. If there
+	 * @return Returns an instance of {@code BootstrapConfiguration}. This method returns never {@code null}. If there
 	 *         is no <i>META-INF/validation.xml</i> the different getters of the returned instance will return {@code null} respective
 	 *         the empty set or map.
 	 */
-	XMLConfiguration getXMLConfiguration();
+	BootstrapConfiguration getBootstrapConfiguration();
 
 	/**
 	 * Build a {@code ValidatorFactory} implementation.


### PR DESCRIPTION
- Renaming ConfigurationSource to XMLConfiguration
- Clarifying the javadocs:
  - Configuration#getXMLConfiguration never returns null and only applies for validation.xml
