### PR TITLE
BVAL-337 ConstraintViolation

### DIFF
--- a/src/main/java/javax/validation/ConstraintViolation.java
+++ b/src/main/java/javax/validation/ConstraintViolation.java
@@ -19,7 +19,7 @@ package javax.validation;
 import javax.validation.metadata.ConstraintDescriptor;
 
 /**
- * Describe a constraint violation. This object exposes the constraint
+ * Describes a constraint violation. This object exposes the constraint
  * violation context as well as the message describing the violation.
  *
  * @author Emmanuel Bernard
@@ -37,25 +37,73 @@ public interface ConstraintViolation<T> {
 	String getMessageTemplate();
 
 	/**
-	 * @return The root bean being validated. Null when returned by
-	 *         {@link javax.validation.Validator#validateValue(Class, String, Object, Class[])}
+	 * Returns the root bean being validated. For method validation, returns
+	 * the object the method is executed on.
+	 *
+	 * Returns {@code null} when:
+	 * <ul>
+	 *     <li>the {@code ConstraintViolation} is returned after calling
+	 *     {@link javax.validation.Validator#validateValue(Class, String, Object, Class[])}</li>
+	 *     <li>the {@code ConstraintViolation} is returned after validating a
+	 *     constructor.</li>
+	 * </ul>
+	 *
+	 * @return The validated object, the object hosting the validated element or {@code null}
 	 */
 	T getRootBean();
 
 	/**
-	 * @return The class of the root bean being validated
+	 * Returns the class of the root bean being validated.
+	 * For method validation, this is the object class the
+	 * method is executed on.
+	 * For constructor validation, this is the class the constructor
+	 * is declared on.
+	 *
+	 * @return The class of the root bean or of the object hosting the validated element
 	 */
 	Class<T> getRootBeanClass();
 
 	/**
-	 * If a bean constraint, the bean instance the constraint is applied on
-	 * If a property constraint, the bean instance hosting the property the
-	 * constraint is applied on
+	 * Returns:
+	 * <ul>
+	 *     <li>the bean instance the constraint is applied on if it is
+	 *     a bean constraint</li>
+	 *     <li>the bean instance hosting the property the constraint
+	 *     is applied on if it is a property constraint</li>
+	 *     <li>the object the method is executed on if it is
+	 *     a method parameter, cross-parameter or return value constraint</li>
+	 *     <li>{@code null} if it is a constructor parameter or
+	 *     cross-parameter constraint</li>
+	 *     <li>the object the constructor has created if it is a
+	 *     constructor return value constraint</li>
+	 * </ul>
 	 *
-	 * @return the leaf bean the constraint is applied on. Null when returned by
-	 *         {@link javax.validation.Validator#validateValue(Class, String, Object, Class[])}
+	 * @return the leaf bean
 	 */
 	Object getLeafBean();
+
+	/**
+	 * Returns an {@code Object[]} representing the constructor or method invocation
+	 * arguments if the {@code ConstraintViolation} is returned after validating the
+	 * method or constructor parameters.
+	 * Returns {@code null} otherwise.
+	 *
+	 * @return parameters of the method or constructor invocation or {@code null}
+	 * @since 1.1
+	 */
+	Object[] getExecutableParameters();
+
+	/**
+	 * Returns the return value of the constructor or method invocation
+	 * if the {@code ConstraintViolation} is returned after validating the method
+	 * or constructor return value.
+	 * {@code null} is returned if the method has no return value.
+	 * Returns {@code null} otherwise.
+	 *
+	 * @return the method or constructor return value or {@code null}
+	 * @since 1.1
+	 */
+	Object getExecutableReturnValue();
 
 	/**
 	 * @return the property path to the value from {@code rootBean}.


### PR DESCRIPTION
Feedback welcome @gmorling @hhferentschik

I ended up:
- adding getExecutableReturnValue and getExecutableParameters
- make getRootBean return null for Constructors (it's really a return value)
- still make getRootBeanClass return the class hosting the constructor

The problem is that Constructor is a "static" method if you think about it.
