### PR TITLE
Use the same lock for all methods accessing Validation.GetValidationProviderListAction#providersPerClassloader

### DIFF
--- a/src/main/java/jakarta/validation/Validation.java
+++ b/src/main/java/jakarta/validation/Validation.java
@@ -163,7 +163,7 @@ public class Validation {
 	 */
 	@SuppressWarnings("unused")
 	private static void clearDefaultValidationProviderResolverCache() {
-		GetValidationProviderListAction.clearCache();
+		GetValidationProviderListAction.INSTANCE.clearCache();
 	}
 
 	//private class, not exposed
@@ -339,8 +339,8 @@ public class Validation {
 			}
 		}
 
-		public static synchronized void clearCache() {
-			INSTANCE.providersPerClassloader.clear();
+		public synchronized void clearCache() {
+			providersPerClassloader.clear();
 		}
 
 		@Override


### PR DESCRIPTION
`clearCache` was a static method and thus was synchronized on the class,
while `getCachedValidationProviders`/`cacheValidationProviders`
are instance methods and thus are synchronized on a particular instance.
This means it was theoretically possible for `clearCache` and
`getCachedValidationProviders`/`cacheValidationProviders` to access the
providersPerClassloader map concurrently,
which is a problem because WeakHashMap is not thread-safe.

This may fix #180, though it's hard to say without a proper thread dump
showing what the cause of the deadlock was exactly.

In any case, this will prevent synchronization issues for integrators
that call Validation#clearDefaultValidationProviderResolverCache
concurrently to Validation.DefaultValidationProviderResolver#getValidationProviders.

Fixes #180 (possibly?)