### PR TITLE
Add Jakarta Validation 3.1 XSDs

### DIFF
--- a/src/main/xsd/validation-configuration-1.1.xsd
+++ b/src/main/xsd/validation-configuration-1.1.xsd
@@ -14,10 +14,10 @@
 
     <xs:annotation>
         <xs:documentation><![CDATA[
-            This is the XML Schema for the Jakarta Validation configuration file.
+            This is the XML Schema for the Jakarta Bean Validation configuration file.
             The configuration file must be named "META-INF/validation.xml".
 
-            Jakarta Validation configuration files must indicate the Jakarta Validation
+            Jakarta Bean Validation configuration files must indicate the Jakarta Bean Validation
             XML schema by using the validation namespace:
 
             http://jboss.org/xml/ns/javax/validation/configuration

--- a/src/main/xsd/validation-configuration-2.0.xsd
+++ b/src/main/xsd/validation-configuration-2.0.xsd
@@ -14,10 +14,10 @@
 
     <xs:annotation>
         <xs:documentation><![CDATA[
-            This is the XML Schema for the Jakarta Validation configuration file.
+            This is the XML Schema for the Jakarta Bean Validation configuration file.
             The configuration file must be named "META-INF/validation.xml".
 
-            Jakarta Validation configuration files must indicate the Jakarta Validation
+            Jakarta Bean Validation configuration files must indicate the Jakarta Bean Validation
             XML schema by using the validation namespace:
 
             http://xmlns.jcp.org/xml/ns/validation/configuration

--- a/src/main/xsd/validation-configuration-3.0.xsd
+++ b/src/main/xsd/validation-configuration-3.0.xsd
@@ -14,10 +14,10 @@
 
     <xs:annotation>
         <xs:documentation><![CDATA[
-            This is the XML Schema for the Jakarta Validation configuration file.
+            This is the XML Schema for the Jakarta Bean Validation configuration file.
             The configuration file must be named "META-INF/validation.xml".
 
-            Jakarta Validation configuration files must indicate the Jakarta Validation
+            Jakarta Bean Validation configuration files must indicate the Jakarta Bean Validation
             XML schema by using the validation namespace:
 
             https://jakarta.ee/xml/ns/validation/configuration

--- a/src/main/xsd/validation-configuration-3.1.xsd
+++ b/src/main/xsd/validation-configuration-3.1.xsd
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Jakarta Validation API
+  ~
+  ~ License: Apache License, Version 2.0
+  ~ See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+  -->
+<xs:schema attributeFormDefault="unqualified"
+           elementFormDefault="qualified"
+           targetNamespace="https://jakarta.ee/xml/ns/validation/configuration"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:config="https://jakarta.ee/xml/ns/validation/configuration"
+           version="3.1">
+
+    <xs:annotation>
+        <xs:documentation><![CDATA[
+            This is the XML Schema for the Jakarta Validation configuration file.
+            The configuration file must be named "META-INF/validation.xml".
+
+            Jakarta Validation configuration files must indicate the Jakarta Validation
+            XML schema by using the validation namespace:
+
+            https://jakarta.ee/xml/ns/validation/configuration
+
+            and indicate the version of the schema by using the version attribute
+            as shown below:
+
+            <validation-config
+                xmlns="https://jakarta.ee/xml/ns/validation/configuration"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:schemaLocation="
+                    https://jakarta.ee/xml/ns/validation/configuration
+                    https://jakarta.ee/xml/ns/validation/validation-configuration-3.1.xsd"
+                version="3.1">
+                [...]
+            </validation-config>
+        ]]>
+        </xs:documentation>
+    </xs:annotation>
+
+    <xs:element name="validation-config" type="config:validation-configType"/>
+    <xs:complexType name="validation-configType">
+        <xs:sequence>
+            <xs:element type="xs:string" name="default-provider" minOccurs="0"/>
+            <xs:element type="xs:string" name="message-interpolator" minOccurs="0"/>
+            <xs:element type="xs:string" name="traversable-resolver" minOccurs="0"/>
+            <xs:element type="xs:string" name="constraint-validator-factory" minOccurs="0"/>
+            <xs:element type="xs:string" name="parameter-name-provider" minOccurs="0"/>
+            <xs:element type="xs:string" name="clock-provider" minOccurs="0"/>
+            <xs:element type="xs:string" name="value-extractor" maxOccurs="unbounded"
+                    minOccurs="0"/>
+            <xs:element type="config:executable-validationType" name="executable-validation"
+                    minOccurs="0"/>
+            <xs:element type="xs:string" name="constraint-mapping" maxOccurs="unbounded"
+                    minOccurs="0"/>
+            <xs:element type="config:propertyType" name="property" maxOccurs="unbounded"
+                    minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="version" type="config:versionType" fixed="3.0" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="executable-validationType">
+        <xs:sequence>
+            <xs:element type="config:default-validated-executable-typesType"
+                    name="default-validated-executable-types" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="enabled" use="optional" type="xs:boolean" default="true"/>
+    </xs:complexType>
+    <xs:complexType name="default-validated-executable-typesType">
+        <xs:sequence>
+            <xs:element name="executable-type" maxOccurs="unbounded" minOccurs="1">
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="NONE"/>
+                        <xs:enumeration value="CONSTRUCTORS"/>
+                        <xs:enumeration value="NON_GETTER_METHODS"/>
+                        <xs:enumeration value="GETTER_METHODS"/>
+                        <xs:enumeration value="ALL"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="propertyType">
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:attribute name="name" use="required" type="xs:string"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+    <xs:simpleType name="versionType">
+        <xs:restriction base="xs:token">
+            <xs:pattern value="[0-9]+(\.[0-9]+)*" />
+        </xs:restriction>
+    </xs:simpleType>
+</xs:schema>

--- a/src/main/xsd/validation-mapping-1.1.xsd
+++ b/src/main/xsd/validation-mapping-1.1.xsd
@@ -14,9 +14,9 @@
 
     <xs:annotation>
         <xs:documentation><![CDATA[
-            This is the XML Schema for Jakarta Validation constraint mapping files.
+            This is the XML Schema for Jakarta Bean Validation constraint mapping files.
 
-            Jakarta Validation constraint mapping files must indicate the Jakarta Validation
+            Jakarta Bean Validation constraint mapping files must indicate the Jakarta Bean Validation
             XML schema by using the constraint mapping namespace:
 
             http://jboss.org/xml/ns/javax/validation/mapping

--- a/src/main/xsd/validation-mapping-2.0.xsd
+++ b/src/main/xsd/validation-mapping-2.0.xsd
@@ -14,9 +14,9 @@
 
     <xs:annotation>
         <xs:documentation><![CDATA[
-            This is the XML Schema for Jakarta Validation constraint mapping files.
+            This is the XML Schema for Jakarta Bean Validation constraint mapping files.
 
-            Jakarta Validation constraint mapping files must indicate the Jakarta Validation
+            Jakarta Bean Validation constraint mapping files must indicate the Jakarta Bean Validation
             XML schema by using the constraint mapping namespace:
 
             http://xmlns.jcp.org/xml/ns/validation/mapping

--- a/src/main/xsd/validation-mapping-3.0.xsd
+++ b/src/main/xsd/validation-mapping-3.0.xsd
@@ -14,9 +14,9 @@
 
     <xs:annotation>
         <xs:documentation><![CDATA[
-            This is the XML Schema for Jakarta Validation constraint mapping files.
+            This is the XML Schema for Jakarta Bean Validation constraint mapping files.
 
-            Jakarta Validation constraint mapping files must indicate the Jakarta Validation
+            Jakarta Bean Validation constraint mapping files must indicate the Jakarta Bean Validation
             XML schema by using the constraint mapping namespace:
 
             https://jakarta.ee/xml/ns/validation/mapping

--- a/src/main/xsd/validation-mapping-3.1.xsd
+++ b/src/main/xsd/validation-mapping-3.1.xsd
@@ -1,0 +1,309 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Jakarta Validation API
+  ~
+  ~ License: Apache License, Version 2.0
+  ~ See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+  -->
+<xs:schema attributeFormDefault="unqualified"
+           elementFormDefault="qualified"
+           targetNamespace="https://jakarta.ee/xml/ns/validation/mapping"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:map="https://jakarta.ee/xml/ns/validation/mapping"
+           version="3.1">
+
+    <xs:annotation>
+        <xs:documentation><![CDATA[
+            This is the XML Schema for Jakarta Validation constraint mapping files.
+
+            Jakarta Validation constraint mapping files must indicate the Jakarta Validation
+            XML schema by using the constraint mapping namespace:
+
+            https://jakarta.ee/xml/ns/validation/mapping
+
+            and indicate the version of the schema by using the version attribute
+            as shown below:
+
+            <constraint-mappings
+                xmlns="https://jakarta.ee/xml/ns/validation/mapping"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:schemaLocation="
+                    https://jakarta.ee/xml/ns/validation/mapping
+                    https://jakarta.ee/xml/ns/validation/validation-mapping-3.1.xsd"
+                version="3.1">
+                ...
+            </constraint-mappings>
+        ]]>
+        </xs:documentation>
+    </xs:annotation>
+
+    <xs:element name="constraint-mappings" type="map:constraint-mappingsType"/>
+
+    <xs:complexType name="payloadType">
+        <xs:sequence>
+            <xs:element type="xs:string" name="value" maxOccurs="unbounded" minOccurs="0"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="groupsType">
+        <xs:sequence>
+            <xs:element type="xs:string" name="value" maxOccurs="unbounded" minOccurs="0"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="groupSequenceType">
+        <xs:sequence>
+            <xs:element type="xs:string" name="value" maxOccurs="unbounded" minOccurs="0"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="groupConversionType">
+        <xs:attribute type="xs:string" name="from" use="optional"/>
+        <xs:attribute type="xs:string" name="to" use="required"/>
+    </xs:complexType>
+    <xs:complexType name="constraint-mappingsType">
+        <xs:sequence>
+            <xs:element type="xs:string" name="default-package" minOccurs="0"/>
+            <xs:element type="map:beanType"
+                        name="bean"
+                        maxOccurs="unbounded"
+                        minOccurs="0"/>
+            <xs:element type="map:constraint-definitionType"
+                        name="constraint-definition"
+                        maxOccurs="unbounded"
+                        minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="version" type="map:versionType" fixed="3.0" use="required"/>
+    </xs:complexType>
+    <xs:simpleType name="versionType">
+        <xs:restriction base="xs:token">
+            <xs:pattern value="[0-9]+(\.[0-9]+)*"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:complexType name="validated-byType">
+        <xs:sequence>
+            <xs:element type="xs:string" name="value" maxOccurs="unbounded" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute type="xs:boolean" name="include-existing-validators" use="optional"/>
+    </xs:complexType>
+    <xs:complexType name="constraintType">
+        <xs:sequence>
+            <xs:element type="xs:string" name="message" minOccurs="0"/>
+            <xs:element type="map:groupsType"
+                        name="groups"
+                        minOccurs="0"/>
+            <xs:element type="map:payloadType"
+                        name="payload"
+                        minOccurs="0"/>
+            <xs:element type="map:elementType"
+                        name="element"
+                        maxOccurs="unbounded"
+                        minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute type="xs:string" name="annotation" use="required"/>
+    </xs:complexType>
+    <xs:complexType name="elementType" mixed="true">
+        <xs:sequence>
+            <xs:element type="xs:string" name="value" maxOccurs="unbounded" minOccurs="0"/>
+            <xs:element type="map:annotationType"
+                        name="annotation"
+                        maxOccurs="unbounded"
+                        minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute type="xs:string" name="name" use="required"/>
+    </xs:complexType>
+    <xs:complexType name="containerElementTypeType">
+        <xs:sequence>
+            <xs:element type="xs:string" name="valid" minOccurs="0" fixed=""/>
+            <xs:element type="map:groupConversionType"
+                        name="convert-group"
+                        minOccurs="0"
+                        maxOccurs="unbounded"/>
+            <xs:element type="map:containerElementTypeType"
+                        name="container-element-type"
+                        maxOccurs="unbounded"
+                        minOccurs="0"/>
+            <xs:element type="map:constraintType"
+                        name="constraint"
+                        maxOccurs="unbounded"
+                        minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="type-argument-index" use="optional">
+            <xs:simpleType>
+                <xs:restriction base="xs:int">
+                    <xs:minInclusive value="0" />
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+    <xs:complexType name="classType">
+        <xs:sequence>
+            <xs:element type="map:groupSequenceType"
+                        name="group-sequence"
+                        minOccurs="0"/>
+            <xs:element type="map:constraintType"
+                        name="constraint"
+                        maxOccurs="unbounded"
+                        minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute type="xs:boolean" name="ignore-annotations" use="optional"/>
+    </xs:complexType>
+    <xs:complexType name="beanType">
+        <xs:sequence>
+            <xs:element type="map:classType"
+                        name="class"
+                        minOccurs="0">
+            </xs:element>
+            <xs:element type="map:fieldType"
+                        name="field"
+                        minOccurs="0"
+                        maxOccurs="unbounded"/>
+            <xs:element type="map:getterType"
+                        name="getter"
+                        minOccurs="0"
+                        maxOccurs="unbounded"/>
+            <xs:element type="map:constructorType"
+                        name="constructor"
+                        minOccurs="0"
+                        maxOccurs="unbounded"/>
+            <xs:element type="map:methodType"
+                        name="method"
+                        minOccurs="0"
+                        maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute type="xs:string" name="class" use="required"/>
+        <xs:attribute type="xs:boolean" name="ignore-annotations" use="optional"
+                default="true"/>
+    </xs:complexType>
+    <xs:complexType name="annotationType">
+        <xs:sequence>
+            <xs:element type="map:elementType"
+                        name="element"
+                        maxOccurs="unbounded"
+                        minOccurs="0"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="getterType">
+        <xs:sequence>
+            <xs:element type="xs:string" name="valid" minOccurs="0" fixed=""/>
+            <xs:element type="map:groupConversionType"
+                        name="convert-group"
+                        minOccurs="0"
+                        maxOccurs="unbounded"/>
+            <xs:element type="map:containerElementTypeType"
+                        name="container-element-type"
+                        minOccurs="0"
+                        maxOccurs="unbounded"/>
+            <xs:element type="map:constraintType"
+                        name="constraint"
+                        minOccurs="0"
+                        maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute type="xs:string" name="name" use="required"/>
+        <xs:attribute type="xs:boolean" name="ignore-annotations" use="optional"/>
+    </xs:complexType>
+    <xs:complexType name="methodType">
+        <xs:sequence>
+            <xs:element type="map:parameterType"
+                        name="parameter"
+                        minOccurs="0"
+                        maxOccurs="unbounded"/>
+            <xs:element type="map:crossParameterType"
+                        name="cross-parameter"
+                        minOccurs="0"
+                        maxOccurs="1"/>
+            <xs:element type="map:returnValueType"
+                        name="return-value"
+                        minOccurs="0"
+                        maxOccurs="1"/>
+        </xs:sequence>
+        <xs:attribute type="xs:string" name="name" use="required"/>
+        <xs:attribute type="xs:boolean" name="ignore-annotations" use="optional"/>
+    </xs:complexType>
+    <xs:complexType name="constructorType">
+        <xs:sequence>
+            <xs:element type="map:parameterType"
+                        name="parameter"
+                        minOccurs="0"
+                        maxOccurs="unbounded"/>
+            <xs:element type="map:crossParameterType"
+                        name="cross-parameter"
+                        minOccurs="0"
+                        maxOccurs="1"/>
+            <xs:element type="map:returnValueType"
+                        name="return-value"
+                        minOccurs="0"
+                        maxOccurs="1"/>
+        </xs:sequence>
+        <xs:attribute type="xs:boolean" name="ignore-annotations" use="optional"/>
+    </xs:complexType>
+    <xs:complexType name="parameterType">
+        <xs:sequence>
+            <xs:element type="xs:string" name="valid" minOccurs="0" fixed=""/>
+            <xs:element type="map:groupConversionType"
+                        name="convert-group"
+                        minOccurs="0"
+                        maxOccurs="unbounded"/>
+            <xs:element type="map:containerElementTypeType"
+                        name="container-element-type"
+                        minOccurs="0"
+                        maxOccurs="unbounded"/>
+            <xs:element type="map:constraintType"
+                        name="constraint"
+                        minOccurs="0"
+                        maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute type="xs:string" name="type" use="required"/>
+        <xs:attribute type="xs:boolean" name="ignore-annotations" use="optional"/>
+    </xs:complexType>
+    <xs:complexType name="returnValueType">
+        <xs:sequence>
+            <xs:element type="xs:string" name="valid" minOccurs="0" fixed=""/>
+            <xs:element type="map:groupConversionType"
+                        name="convert-group"
+                        minOccurs="0"
+                        maxOccurs="unbounded"/>
+            <xs:element type="map:containerElementTypeType"
+                        name="container-element-type"
+                        minOccurs="0"
+                        maxOccurs="unbounded"/>
+            <xs:element type="map:constraintType"
+                        name="constraint"
+                        minOccurs="0"
+                        maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute type="xs:boolean" name="ignore-annotations" use="optional"/>
+    </xs:complexType>
+    <xs:complexType name="crossParameterType">
+        <xs:sequence>
+            <xs:element type="map:constraintType"
+                        name="constraint"
+                        minOccurs="0"
+                        maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute type="xs:boolean" name="ignore-annotations" use="optional"/>
+    </xs:complexType>
+    <xs:complexType name="constraint-definitionType">
+        <xs:sequence>
+            <xs:element type="map:validated-byType"
+                        name="validated-by"/>
+        </xs:sequence>
+        <xs:attribute type="xs:string" name="annotation" use="required"/>
+    </xs:complexType>
+    <xs:complexType name="fieldType">
+        <xs:sequence>
+            <xs:element type="xs:string" name="valid" minOccurs="0" fixed=""/>
+            <xs:element type="map:groupConversionType"
+                        name="convert-group"
+                        minOccurs="0"
+                        maxOccurs="unbounded"/>
+            <xs:element type="map:containerElementTypeType"
+                        name="container-element-type"
+                        minOccurs="0"
+                        maxOccurs="unbounded"/>
+            <xs:element type="map:constraintType"
+                        name="constraint"
+                        minOccurs="0"
+                        maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute type="xs:string" name="name" use="required"/>
+        <xs:attribute type="xs:boolean" name="ignore-annotations" use="optional"/>
+    </xs:complexType>
+</xs:schema>


### PR DESCRIPTION
fixes https://github.com/jakartaee/validation/issues/217

While creating this patch, I noticed that the other XSDs for previous versions are using the new `Jakarta Validation` spec name. Shouldn't the name for the older version remain the same as it was when the corresponding spec was published? 