### PR TITLE
[#278] Update dependabot config to group dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,9 +3,24 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: daily
-
+      interval: "weekly"
+      day: "monday"
+    groups:
+      workflow-actions:
+        patterns:
+          - "*"
+    allow:
+      - dependency-name: "actions/*"
   - package-ecosystem: maven
     directory: /
     schedule:
-      interval: daily
+      interval: "weekly"
+      day: "monday"
+    groups:
+      build-dependencies:
+        patterns:
+          # Maven plugins:
+          - "*maven*plugin*"
+          - "org.apache.maven*:*"
+          # Test dependencies:
+          - "org.testng*"


### PR DESCRIPTION
Let's keep the updates checked weekly so that we don't get a lot of "noise" from all the dependabot PRs

- Closes #278 