### PR TITLE
[#292] Replace JDK 24 with 25

### DIFF
--- a/.github/workflows/ci-pull.yml
+++ b/.github/workflows/ci-pull.yml
@@ -15,22 +15,34 @@ jobs:
 
     strategy:
       matrix:
-        java-version: [ '17', '21', '24' ]
+        java-version:
+          - { name: "17", java_version_numeric: 17 }
+          - { name: "21", java_version_numeric: 21 }
+          - { name: "25", java_version_numeric: 25 }
+          - { name: "26-ea", java_version_numeric: 26, from: 'jdk.java.net' }
 
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-    - name: Set up JDK ${{ matrix.java-version }}
-      uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
+    - name: Checkout the sources
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+    - name: Set up latest JDK ${{ matrix.java-version.name }} from jdk.java.net
+      if: matrix.java-version.from == 'jdk.java.net'
+      uses: oracle-actions/setup-java@2e744f723b003fdd759727d0ff654c8717024845 # v1.4.0
       with:
-        java-version: ${{ matrix.java-version }}
+        website: jdk.java.net
+        release: ${{ matrix.java-version.java_version_numeric }}
+    - name: Set up JDK ${{ matrix.java-version.name }}
+      uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
+      if: matrix.java-version.from != 'jdk.java.net'
+      with:
+        java-version: ${{ matrix.java-version.java_version_numeric }}
         distribution: 'temurin'
         cache: maven
     - name: Build API
       run: |
         EXTRA_ARGS=""
-        if [[ "${{ matrix.java }}" -lt 21 ]]; then
+        if [[ "${{ matrix.java-version.java_version_numeric }}" -lt 21 ]]; then
           # for JDKs < 21 we should skip extra checks as those won't pass:
           EXTRA_ARGS="-Pskip-checks"
         fi


### PR DESCRIPTION
As JDK 25 is not yet available from a temurin distribution, let's set up the one from jdk.java.net and with that in place, also test against the 26 EA builds.

- Fixes #292